### PR TITLE
Implement basic mobile navigation, basic signup skeleton

### DIFF
--- a/stonks_frontend/App.js
+++ b/stonks_frontend/App.js
@@ -4,14 +4,18 @@ import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import { AppRegistry, StyleSheet, Text, View } from 'react-native';
 import Login from './welcome/components/Login/Login';
+import Signup from './welcome/components/Signup/Signup';
+import Landing from './welcome/components/Landing/Landing';
 
 
 const Authstack = createStackNavigator(); 
 
 export default ()=>(
   <NavigationContainer>
-    <Authstack.Navigator>
-      <Authstack.Screen name = "Login" component = {Login}/>
+    <Authstack.Navigator initialRouteName="Landing">
+      <Authstack.Screen name="Landing" component={Landing} />
+      <Authstack.Screen name="Signup" component={Signup}/>
+      <Authstack.Screen name="Login" component={Login}/>
     </Authstack.Navigator>
   </NavigationContainer>
 );

--- a/stonks_frontend/welcome/components/Landing/Landing.js
+++ b/stonks_frontend/welcome/components/Landing/Landing.js
@@ -1,0 +1,75 @@
+import { StatusBar } from 'expo-status-bar';
+import React, { Component } from 'react';
+import { StyleSheet, View, Image, Text, Button } from 'react-native';
+
+class Landing extends Component {
+  render() {
+    return (
+      <View styles = {styles.container}>
+        <View style = {styles.logoContainer}>
+          <Image 
+          style = {styles.logo}
+          source ={require('../../Images/icon.png')}
+          />
+          <Text style = {styles.title}>Welcome to StonkStache</Text>
+
+
+        </View>
+
+        <View styles = {styles.buttonContainer}>
+          { /* Put buttons here */ }
+          <Button
+            styles = {styles.buttonText}
+            onPress={ () => this.props.navigation.navigate('Signup')}
+            title="Signup"
+            accessibilityLabel="Signup Button"
+            />
+          <Button
+            styles = {styles.buttonText}
+            onPress={ () => this.props.navigation.navigate('Login')}
+            title="Login"
+            accessibilityLabel="Login Button"
+            />
+
+
+        </View>
+       
+      </View>//styles container
+      
+     
+    );
+  }
+}
+
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    justifyContent:'center'
+  },
+
+  logoContainer:{
+    flexGrow:1000,
+    alignItems: 'center', 
+    justifyContent: 'center',
+  },
+
+  logo:{
+    width: 100, 
+    height: 100
+  },
+  buttonContainer:{
+    backgroundColor: '#1dd1a1',
+    paddingVertical: 10, 
+    textAlign:'center',
+  },
+  buttonText:{
+    textAlign:'center', 
+    color: '#FFFFFF'
+}
+
+  
+});
+
+export default Landing;

--- a/stonks_frontend/welcome/components/Login/Loginform.js
+++ b/stonks_frontend/welcome/components/Login/Loginform.js
@@ -9,11 +9,14 @@ export default class Loginform extends Component {
        <TextInput 
        placeholder= "User"
        placeholderTextColor= '#FFF'
+       textContentType= "username"
        style ={styles.input}
        />
         <TextInput 
         placeholder= "Password"
         placeholderTextColor='#FFF'
+        textContentType= "password"
+        secureTextEntry= { true } 
        style ={styles.input}
        />
 

--- a/stonks_frontend/welcome/components/Signup/Signup.js
+++ b/stonks_frontend/welcome/components/Signup/Signup.js
@@ -1,0 +1,53 @@
+import { StatusBar } from 'expo-status-bar';
+import React, { Component } from 'react';
+import { StyleSheet, View, Image,Text } from 'react-native';
+import Signupform from './Signupform';
+
+class Signup extends Component {
+  render() {
+    return (
+      <View styles = {styles.container}>
+        <View style = {styles.logoContainer}>
+          <Image 
+          style = {styles.logo}
+          source ={require('../../Images/icon.png')}
+          />
+          <Text style = {styles.title}>Welcome to StonkStache</Text>
+
+
+        </View>
+
+        <View styles = {styles.formContainer}>
+          <Signupform navigation = {this.props.navigation}/>
+        </View>
+       
+      </View>//styles container
+      
+     
+    );
+  }
+}
+
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    justifyContent:'center'
+  },
+
+  logoContainer:{
+    flexGrow:1000,
+    alignItems: 'center', 
+    justifyContent: 'center',
+  },
+
+  logo:{
+    width: 100, 
+    height: 100
+  }
+
+  
+});
+
+export default Signup;

--- a/stonks_frontend/welcome/components/Signup/Signupform.js
+++ b/stonks_frontend/welcome/components/Signup/Signupform.js
@@ -1,0 +1,100 @@
+import { StatusBar } from 'expo-status-bar';
+import React, {Component} from 'react';
+import {StyleSheet, Text, TextInput, View, Button, TouchableOpacity } from 'react-native';
+
+class Signupform extends Component {
+
+  state = { username: "", email: "", email2: "", password: "", password2: ""};
+  
+  render(){
+    return (
+      <View style ={styles.container}>
+        <TextInput 
+          placeholder="Username"
+          placeholderTextColor='#FFF'
+          textContentType="username"
+          style ={styles.input}
+          value ={this.state.username}
+          onChangeText = { text => this.setState({username: text})} 
+          />
+        <TextInput 
+          placeholder= "Email"
+          placeholderTextColor= '#FFF'
+          textContentType= "emailAddress"
+          style ={styles.input}
+          value = {this.state.email}
+          onChangeText = { text => this.setState({email: text})} 
+          />
+        <TextInput 
+          placeholder= "Confirm Email"
+          placeholderTextColor= '#FFF'
+          textContentType= "emailAddress"
+          style ={styles.input}
+          value = {this.state.email2}
+          onChangeText = { text => this.setState({email2: text})} 
+          />
+        <TextInput 
+          placeholder= "Password"
+          placeholderTextColor='#FFF'
+          textContentType= "password"
+          secureTextEntry= { true } 
+          style ={styles.input}
+          value = {this.state.password}
+          onChangeText = { text => this.setState({password: text})} 
+          />
+        <TextInput 
+          placeholder= "Confirm Password"
+          placeholderTextColor='#FFF'
+          textContentType= "password"
+          secureTextEntry= { true } 
+          style ={styles.input}
+          value = {this.state.password2}
+          onChangeText = { text => this.setState({password2: text})} 
+          />
+
+        <TouchableOpacity style={styles.buttonContainer}>
+          <Button style={styles.buttonText}
+            onPress={ () => {
+                // Once authentication routes are made, submit stuff here.
+                // ensure validation of email, password, username, etc and rejection if bad
+                // TODO: determine requirements for each field.
+                this.props.navigation.navigate('Login');
+            } }
+            title="Submit"/>
+
+
+       </TouchableOpacity>
+      </View>
+      
+   
+    );
+
+  }
+  
+}
+
+const styles = StyleSheet.create({
+  container: {
+      padding:20
+  },
+  input:{
+      height:40,
+      backgroundColor: '#55efc4',
+      marginBottom:20, 
+      paddingHorizontal: 10,
+      textAlign: 'center'  
+
+  },
+  buttonContainer:{
+      backgroundColor: '#1dd1a1',
+      paddingVertical: 10, 
+      textAlign:'center',
+  },
+  buttonText:{
+      textAlign:'center', 
+      color: '#FFFFFF'
+  }
+
+});
+
+export default Signupform;


### PR DESCRIPTION
Implemented basic navigation.
Added a landing page from which to navigate to the Signup Screen or Login Screen.
* As of now the Submit button on the Signup Screen just navigates to Login Screen, until the back end bums want to make user auth and the proper routes.